### PR TITLE
Add files to make sure SuperSU know it is rooted

### DIFF
--- a/preinstall/99SuperSUDaemon
+++ b/preinstall/99SuperSUDaemon
@@ -1,0 +1,2 @@
+#!/system/bin/sh
+/system/xbin/daemonsu --auto-daemon &

--- a/preinstall/preinstall.mk
+++ b/preinstall/preinstall.mk
@@ -16,5 +16,7 @@ PRODUCT_COPY_FILES += \
         device/rockchip/rk3188/preinstall/default_wallpaper.jpg:system/media/rkfactory/default_wallpaper.jpg\
 	device/rockchip/rk3188/preinstall/busybox:system/xbin/busybox \
 	device/rockchip/rk3188/preinstall/su:system/xbin/su \
+	device/rockchip/rk3188/preinstall/su:system/xbin/daemonsu \
+	device/rockchip/rk3188/preinstall/99SuperSUDaemon:system/etc/init.d/99SuperSUDaemon \
 
 


### PR DESCRIPTION
This requires /system/etc/init.d/ support

Also SuperSU always seems to think "The SU binary needs to be updated", no matter what I do. It will update fine, but I haven't been able to figure out exactly what it needs so it doesn't always prompt for that.
