### PR TITLE
Enable voice support

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -35,6 +35,7 @@ ro.sf.hwrotation=0
 ro.rk.MassStorage=false
 ro.rk.systembar.voiceicon=true
 ro.rk.systembar.tabletUI=true
+ro.voice.capable=true
 ro.config.hw_quickpoweron=true
 debug.sf.hw=1 
 debug.performance.tuning=1 


### PR DESCRIPTION
Tells TelephonyManager that we do support voice calls on this device.  This makes the people app able to dial contacts again.  
Also reenables the phone app which is works fine although the dialer layout is not designed for landscape. 
